### PR TITLE
HTML -> Markdown

### DIFF
--- a/content/writing-html.md
+++ b/content/writing-html.md
@@ -12,7 +12,7 @@ github:
 {% include box.html type="start" title="Summary" class="" %}
 {:/}
 
-In General HTML can be used for content, but it has disadvantages compared to HTML.
+In General HTML can be used for content, but it has disadvantages compared to Markdown.
 
 {::nomarkdown}
 {% include box.html type="end" %}


### PR DESCRIPTION
This corrects what I think is a typo. Where it says HTML it should say Markdown.