### PR TITLE
Allow multiple resource refs, prefer nav title 

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -63,9 +63,20 @@
   <main id="main"{% if page.lang %} lang="{{page.lang}}"{% endif %}>
     <header{%- if page.resource.ref %}{%- unless page.ref == page.resource.ref %} class="in-resource"{%- endunless -%}{%- endif -%}>
       <h1>{% if page.title_icon %}<svg class="icon-in-title" aria-hidden="true"><use xlink:href="{{page.title_icon | relative_url}}"></use></svg> {% endif %}{% if page.title_image %}<img src="{{page.title_image | relative_url }}" alt="" class="title-image right" style="height: 2em;"> {% endif %}{% if page.title_html %}{{ page.title_html }}{% else %}{{ page.title | xml_escape }}{% endif %}</h1>
-      {%- if page.resource.ref -%}{%- unless page.ref == page.resource.ref -%}
-        <p>{% include t.html t="in" %} {% include link.html to=page.resource.ref %}</p>
-      {%- endunless -%}{%- endif -%}
+      {%- if page.resource.ref -%}
+      <p>
+      {%- for resourceref in page.resource.ref -%}
+        {%- unless page.ref == resourceref -%}
+        {% if forloop.first == true %}
+          {% include t.html t="in" %} 
+          {% include link.html to=resourceref usenavtitle="true" %}
+        {% else %}
+        , {% include link.html to=resourceref usenavtitle="true" %}       
+        {% endif %}
+        {%- endunless -%}
+      {%- endfor -%}
+      {%- endif -%}
+      </p>
     </header>
 
     {%- include doc-note-msg.html -%}


### PR DESCRIPTION
When a page has this in front matter:

```yaml
resource:
  ref: /resource/
```

it will include “in [link to resource]” underneath page title.

## Allow for multiple references 

This PR expands this behavior, so that now a _list of refs_ can be added, like so: 

```yaml
resource:
  ref:
    - /resource-1/
    - /resource-2/
``` 

## Prefer nav title

This used to display the page title as link text. 

It is now updated to use the _nav title_ instead, falling back to page title if there is no nav title set.