### PR TITLE
Apply url_encode to mailto: subject & body params

### DIFF
--- a/_includes/feedback-box.html
+++ b/_includes/feedback-box.html
@@ -44,16 +44,16 @@
 
 {%- include box.html type="start" title=helptitle h=2 class="icon space-above" icon="comments" id="helpimprove" -%}
 {%- if page.lang -%}
-    {%- assign url_title = "[" | append: page.lang | append: "] " | append: page.title | url_encode -%}
+    {%- assign url_title = "[" | append: page.lang | append: "] " | append: page.title | url_encode | replace: "+", "%20" -%}
 {%- else -%}
-    {%- assign url_title = page.title | url_encode -%}
+    {%- assign url_title = page.title | url_encode | replace: "+", "%20" -%}
 {%- endif -%}
 {% unless feedbackmail == "wai@w3.org" %}
 {%- capture mailbody -%}{% include t.html t="[put comment here...]" %}{%- endcapture -%}
 {% else %}
 {%- capture mailbody -%}{% include t.html t="[put comment here...]\n\nI give permission to share this to a publicly-archived e-mail list." %}"}{%- endcapture -%}
 {% endunless %}
-{%- assign mailbody = mailbody | url_encode -%}
+{%- assign mailbody = mailbody | url_encode | replace: "+", "%20" -%}
 {{- helpdesc | replace: "%s", url_title | markdownify -}}
 <div class="button-group">
     <a href="{{ "mailto:" | append: feedbackmail | append: "?subject=%s" | replace: "%s", url_title | append: "&body=" | append: mailbody }}" class="button"><span>{% include t.html t="E-mail" %}</span></a>

--- a/_includes/feedback-box.html
+++ b/_includes/feedback-box.html
@@ -44,16 +44,16 @@
 
 {%- include box.html type="start" title=helptitle h=2 class="icon space-above" icon="comments" id="helpimprove" -%}
 {%- if page.lang -%}
-    {%- assign url_title = "[" | append: page.lang | append: "] " | append: page.title | uri_escape -%}
+    {%- assign url_title = "[" | append: page.lang | append: "] " | append: page.title | url_encode -%}
 {%- else -%}
-    {%- assign url_title = page.title | uri_escape -%}
+    {%- assign url_title = page.title | url_encode -%}
 {%- endif -%}
 {% unless feedbackmail == "wai@w3.org" %}
 {%- capture mailbody -%}{% include t.html t="[put comment here...]" %}{%- endcapture -%}
 {% else %}
 {%- capture mailbody -%}{% include t.html t="[put comment here...]\n\nI give permission to share this to a publicly-archived e-mail list." %}"}{%- endcapture -%}
 {% endunless %}
-{%- assign mailbody = mailbody | uri_escape -%}
+{%- assign mailbody = mailbody | url_encode -%}
 {{- helpdesc | replace: "%s", url_title | markdownify -}}
 <div class="button-group">
     <a href="{{ "mailto:" | append: feedbackmail | append: "?subject=%s" | replace: "%s", url_title | append: "&body=" | append: mailbody }}" class="button"><span>{% include t.html t="E-mail" %}</span></a>


### PR DESCRIPTION
I'm guessing this is used by various apps, beyond the WCAG docs where I've noticed it..

But, over in those docs, the `mailto` link in the footer box has a kind of strange mix of escaping, for example on [this page](https://www.w3.org/WAI/standards-guidelines/wcag/new-in-21/)

```html
<a href="mailto:wai-eo-editors@w3.org?subject=[en]%20What%E2%80%99s%20New%20in%20WCAG%202.1&amp;body=[put%20comment%20here...]" class="button"><span>E-mail</span></a>
```

[MDN](https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks#specifying_details) suggests [URL (percent) encoding](https://shopify.github.io/liquid/filters/url_encode/) the value of each field, producing something like:

```html
<a href="mailto:wai-eo-editors@w3.org?subject=%5Ben%5D%20What%E2%80%99s%20New%20in%20WCAG%202.1&amp;body=%5Bput%20comment%20here...%5D%0D%0A" class="button"><span>E-mail</span></a>
```

Note; I'm not sure how the `&` character just before `body` is being translated to `&amp;`, but I think this change will at least encode the `[ ]` characters to percent values.


