### PR TITLE
Remove stray characters added to mailto body

### DIFF
--- a/_includes/feedback-box.html
+++ b/_includes/feedback-box.html
@@ -51,7 +51,7 @@
 {% unless feedbackmail == "wai@w3.org" %}
 {%- capture mailbody -%}{% include t.html t="[put comment here...]" %}{%- endcapture -%}
 {% else %}
-{%- capture mailbody -%}{% include t.html t="[put comment here...]\n\nI give permission to share this to a publicly-archived e-mail list." %}"}{%- endcapture -%}
+{%- capture mailbody -%}{% include t.html t="[put comment here...]\n\nI give permission to share this to a publicly-archived e-mail list." %}{%- endcapture -%}
 {% endunless %}
 {%- assign mailbody = mailbody | uri_escape -%}
 {{- helpdesc | replace: "%s", url_title | markdownify -}}


### PR DESCRIPTION
<img width="948" alt="Screen Shot 2021-03-15 at 3 05 09 pm" src="https://user-images.githubusercontent.com/351763/111535137-e7f31100-87bc-11eb-83a9-7d784fe307d1.png">
