### PR TITLE
Rename supporting_documents to standalone_resource

### DIFF
--- a/_layouts/minimal.html
+++ b/_layouts/minimal.html
@@ -37,41 +37,155 @@
   {%- endunless -%}
   {% include_cached head.html type="end" %}
   <body id="top" class="page-{{page.title | slugify}} {% include_cached body-class.html collection=page.collection doc-note-type=page.doc-note-type %}">
-    {% include header-minimal.html translations=translations %}
+
+    <div class="minimal-header-container default-grid">
+      {% if site.supporting_doc_name_sub %}
+      {% include minimal-header.html translations=translations class="with-subtitle" subtitle=site.supporting_doc_name_sub title=site.supporting_doc_name %}
+      {% elsif site.supporting_doc_name %}
+      {% include minimal-header.html translations=translations title=site.supporting_doc_name %}
+      {% elsif page.supporting_doc_name_sub %}
+      {% include minimal-header.html translations=translations class="with-subtitle" subtitle=page.supporting_doc_name_sub title=page.supporting_doc_name %}
+      {% else %}
+      {% include minimal-header.html translations=translations title=page.supporting_doc_name %}
+      {% endif %}
+    </div>
+
+    <div class="default-grid nav-container">
+      {% if site.supporting_doc_nav_links or page.supporting_doc_nav_links %}
+      <nav class="nav" aria-label="Context for this document">
+        <ul>
+            {% for link in site.supporting_doc_nav_links %}
+            <li class="nav__item"><a href="{{ link.ref | relative_url }}"{% if page.permalink == link.ref %} class="active" aria-current="page"{% endif %}>{{ link.name }}</a></li>
+            {% endfor %}
+            {% for link in page.supporting_doc_nav_links %}
+            <li class="nav__item"><a href="{{ link.ref | relative_url }}"{% if page.permalink == link.ref %} class="active" aria-current="page"{% endif %}>{{ link.name }}</a></li>
+            {% endfor %}
+            <li class="nav__item"><a href="https://w3c.github.io/wai-wcag-supporting-documents-redesign/alt-index.html">All WCAG 2 Guidance</a></li>
+        </ul>
+      </nav>
+      {% endif %}
+    </div>
+
     <div class="default-grid with-gap leftcol">
-  <main id="main"{% if page.lang %} lang="{{page.lang}}"{% endif %} style="grid-column-start: 2;">
-    <header{%- if page.resource.ref %}{%- unless page.ref == page.resource.ref %} class="in-resource"{%- endunless -%}{%- endif -%}>
-    <h1>{% if page.title_icon %}<svg class="icon-in-title" aria-hidden="true"><use xlink:href="{{page.title_icon | relative_url}}"></use></svg> {% endif %}{% if page.title_html %}{{ page.title_html }}{% else %}{{ page.title }}{% endif %}</h1>
-      {%- if page.resource.ref -%}{%- unless page.ref == page.resource.ref -%}
-        <p>{% include t.html t="in" %} {% include link.html to=page.resource.ref %}</p>
-      {%- endunless -%}{%- endif -%}
-    </header>
+      <main id="main"{% if page.lang %} lang="{{page.lang}}"{% endif %} style="grid-column: 2 / 8; grid-row-start: 1;">
+        <header>
+          <h1>
+            {% if page.type_of_guidance %}
+            <span style="display: block; font-size: .5em; margin-bottom: 0.25em;">{{ page.type_of_guidance }}:</span>
+            {% endif %}
+            {% if page.title_html %}{{ page.title_html }}{% else %}{{ page.title }}{% endif %}
+          </h1>
 
-    {%- include doc-note-msg.html -%}
-    {%- include translation-note-msg.html -%}
+          {% if page.type_of_guidance == "Test Rule" %}
+          <aside class="box"> 
+            <header class="box-h  box-h-icon"> 
+             <svg focusable="false" aria-hidden="true" class="icon-default "> 
+              <use xlink:href="icons.svg#icon-default"></use> 
+             </svg> Conformance Rule 
+            </header> 
+            <div class="box-i"> 
+             <p>This is an <strong>{{ page.rule_meta.type }} rule</strong> 
+              {% if page.rule_meta.related_sc %}
+              to test <strong>{{ page.rule_meta.related_sc }}</strong>
+              {% endif %}
+            </p> 
+            </div>
+           </aside>
+          {% endif %}
+        </header>
 
-    {{ content }}
+        {{ content }}
+      </main>
+    
+        {% if page.type_of_guidance == "Pattern" %}
+        <aside class="your-report your-report--expanded sidebar" style="grid-column: 8 / 10; grid-row-start: 1;">
+          <h2 style="margin-top: 0">About this page</h2>
+          <p><em>COGA Design Patterns</em> are supplemental guidance beyond the requirements of WCAG. They are grouped under “Objectives”. </p>
+          <dl>
+            <dt>Related Objective</d>
+            {% assign currentObjective = page.objective %}
+            {% for objective in site.objectives %}
+            {% if objective.ref == currentObjective %}
+            <dd><a href="{{ objective.url | relative_url }}">{{ objective.title }}</a></dd>
+            {% endif %}
+            {% endfor %}
+            <dt>Related Patterns</dt>
+            {% for pattern in site.patterns %}
+            {% if pattern.objective == page.objective %}{% unless pattern.title == page.title %}
+            <dd><a href="{{ pattern.url | relative_url }}">{{ pattern.title }}</a></dd>
+            {% endunless %}{% endif %}
+            {% endfor %}
+          </dl>
+            <style>
+              dd {
+                  margin-left: 0!important;
+              }
+          </style>
+        </aside>
+        {% endif %}
 
-    {% if page.wcag_success_criteria or page.wcag_techniques %}
-      {% include resources.html %}
-    {% endif %}
+        {% if page.type_of_guidance == "Objective" %}
+        <aside class="your-report your-report--expanded sidebar" style="grid-column: 8 / 10; grid-row-start: 1;">
+          <h2 style="margin-top: 0">About this Objective</h2>
+          <p><em>COGA Design Patterns</em> are supplemental guidance beyond the requirements of WCAG. They are grouped under “Objectives”. </p>
+          <dl>
+            <dt>Patterns for this Objective</d>
+              {% for pattern in site.patterns %}
+              {% if pattern.objective == page.ref %}
+              <dd><a href="{{ pattern.url | relative_url }}">{{ pattern.title }}</a></dd>
+              {% endif %}
+              {% endfor %}
+          </dl>
+          <style>
+              dd {
+                  margin-left: 0!important;
+              }
+          </style>
+        </aside>
+        {% endif %}
 
-    {%- if page.navigation -%}
-      {%- include prevnext-navigation.html -%}
-    {%- else -%}
-      {%- if page.order -%}
-        {%- include prevnext-order.html -%}
+        {% if page.type_of_guidance == "Test Rule" %}
+        <aside class="your-report your-report--expanded sidebar" style="grid-column: 8 / 10; grid-row-start: 1;">
+          <h2 style="margin-top: 0">About this page</h2>
+          <p><em>Accessibility Conformance Testing (ACT) Rules </em> describe ways to test conformance to WCAG success criteria.</p>
+          <dl>
+              {% if page.rule_meta.type %}
+              <dt>Rule type</d>
+              <dd>{{ page.rule_meta.type }}</dd>
+              {% endif %}
+              {% if page.rule_meta.id %}
+              <dt>Rule ID</d>
+              <dd>{{ page.rule_meta.id }}</dd>
+              {% endif %}
+              {% if page.rule_meta.last_modified %}
+              <dt>Last modified</d>
+              <dd>{{ page.rule_meta.last_modified }}</dd>
+              {% endif %}
+          </dl>
+          <style>
+              dd {
+                  margin-left: 0!important;
+              }
+          </style>
+        </aside>
+        {% endif %}      
+    </div>
+
+    <div class="default-grid with-gap leftcol">
+      <div style="grid-column: 2 / 8">
+      {%- if page.navigation -%}
+        {%- include prevnext-navigation.html -%}
+      {%- else -%}
+        {%- if page.order -%}
+          {%- include prevnext-order.html -%}
+        {%- endif -%}
       {%- endif -%}
-    {%- endif -%}
 
-    {% include feedback-box.html %}
-
-
+      {% include feedback-box.html %}
+      </div>
+    </div>
     {% include_cached backtotop.html lang=page.lang %}
-  </main>
-</div>
-
-{% include footer.html %}
-
+  </div>
+  {% include footer.html %}
   </body>
 </html>

--- a/_layouts/supporting_document.html
+++ b/_layouts/supporting_document.html
@@ -51,6 +51,7 @@
     </div>
 
     <div class="default-grid nav-container">
+      {% if site.supporting_doc_nav_links %}
       <nav class="nav" aria-label="Context for this document">
         <ul>
             {% for link in site.supporting_doc_nav_links %}
@@ -62,13 +63,16 @@
             <li class="nav__item"><a href="https://w3c.github.io/wai-wcag-supporting-documents-redesign/alt-index.html">All WCAG 2 Guidance</a></li>
         </ul>
       </nav>
+      {% endif %}
     </div>
 
     <div class="default-grid with-gap leftcol">
       <main id="main"{% if page.lang %} lang="{{page.lang}}"{% endif %} style="grid-column: 2 / 8; grid-row-start: 1;">
         <header>
           <h1>
+            {% if page.type_of_guidance %}
             <span style="display: block; font-size: .5em; margin-bottom: 0.25em;">{{ page.type_of_guidance }}:</span>
+            {% endif %}
             {% if page.title_html %}{{ page.title_html }}{% else %}{{ page.title }}{% endif %}
           </h1>
 
@@ -183,5 +187,68 @@
     {% include_cached backtotop.html lang=page.lang %}
   </div>
   {% include footer.html %}
+  <script>
+  /*!
+  * Get all following siblings of each element up to but not including the element matched by the selector
+  * (c) 2017 Chris Ferdinandi, MIT License, https://gomakethings.com
+  * @param  {Node}   elem     The element
+  * @param  {String} selector The selector to stop at
+  * @param  {String} filter   The selector to match siblings against [optional]
+  * @return {Array}           The siblings
+  */
+  var nextUntil = function (elem, selector, filter) {
+
+  // Setup siblings array
+  var siblings = [];
+
+  // Get the next sibling element
+  elem = elem.nextElementSibling;
+
+  // As long as a sibling exists
+  while (elem) {
+
+    // If we've reached our match, bail
+    if (elem.matches(selector)) break;
+
+    // If filtering by a selector, check if the sibling matches
+    if (filter && !elem.matches(filter)) {
+      elem = elem.nextElementSibling;
+      continue;
+    }
+
+    // Otherwise, push it to the siblings array
+    siblings.push(elem);
+
+    // Get the next sibling element
+    elem = elem.nextElementSibling;
+
+  }
+
+  return siblings;
+
+  };
+
+  const testcases = document.querySelector("#test-cases");
+  const testcaseEls = nextUntil(testcases, 'h2');
+console.log(testcaseEls);
+  for (let i = 0; i < testcaseEls.length; i++) {
+    let testcaseEl = testcaseEls[i];
+    if (testcaseEl.nodeName === "H3") {
+      var testcaseTypeEls = nextUntil(testcaseEl, 'h3'); 
+      var container = document.createElement('details');
+      var summary = document.createElement('summary');
+
+      testcaseTypeEls[0] = summary.append(testcaseTypeEls[0]);
+      container.append(summary); 
+
+      for (let i = 0; i < testcaseTypeEls.length; i++) {
+        container.append(testcaseTypeEls[i]);
+      }
+
+      console.log('container', container)
+      testcases.append(container);
+    }
+}
+</script>
   </body>
 </html>

--- a/content/demo/WCAG2AA-Conformance.md
+++ b/content/demo/WCAG2AA-Conformance.md
@@ -1,0 +1,35 @@
+---
+title: "Web Content Accessibility Guidelines (WCAG) 2 Level AA Conformance"
+title_html: "Web Content Accessibility Guidelines (WCAG) 2<br>Level AA Conformance"
+permalink: /WCAG2AA-Conformance
+lang: en
+ref: /WCAG2AA-Conformance
+github:
+  repository: wai-intro-wcag
+  path: content/WCAG2AA-Conformance.md
+layout: supporting_document
+class: tight-page
+feedbackmail: wai@w3.org
+footer: > # Text in footer in HTML
+  <p><strong>Date:</strong> Updated 13 July 2020.</p>
+---
+
+  <p><img src="https://www.w3.org/WAI/wcag21/wcag2.1AA-blue-v.png" alt="W3C WAI-AA WCAG 2.1" width="88" height="32"> <img src="https://www.w3.org/WAI/wcag21/wcag2.1AA-v.png" alt="W3C WAI-AA WCAG 2.1" width="88" height="32"> Web pages with one of these logos claim conformance to WCAG 2.1 at Level AA.</p>
+  <p><img src="https://www.w3.org/WAI/wcag2AA-blue.png" alt="W3C WAI-AA WCAG 2.0" width="88" height="32"> <img src="https://www.w3.org/WAI/wcag2AA.png" alt="W3C WAI-AA WCAG 2.0" width="88" height="32"> Web pages with one of these logos claim conformance to WCAG 2.0 at Level AA.</p>
+  <p><strong><em>Important note:</em> Claims are not verified by W3C. Content providers are solely responsible for the use of these logos.</strong></p>
+  <h2>About WCAG</h2>
+  <p>Web Content Accessibility Guidelines (WCAG) explains how to make web content more accessible to people with disabilities. WCAG covers web sites, applications, and other digital content. It is developed by the World Wide Web Consortium (W3C) Web Accessibility Initiative (WAI). WCAG is an international standard.</p>
+  <p>There are three levels of conformance:</p>
+  <ul>
+    <li>Level A is the minimum level.</li>
+    <li>Level AA includes all Level A and AA requirements. Many organizations strive to meet Level AA.</li>
+    <li>Level AAA includes all Level A, AA, and AAA requirements.</li>
+  </ul>
+  <h2>Learn More</h2>
+  <p>To learn more, please see:</p>
+  <ul>
+    <li><strong><a href="https://www.w3.org/WAI/fundamentals/accessibility-intro/" rel="nofollow">Introduction to Web Accessibility</a></strong></li>
+    <li><strong><a href="https://www.w3.org/WAI/standards-guidelines/wcag/" rel="nofollow">Web Content Accessibility Guidelines (WCAG) Overview</a></strong></li>
+  </ul>
+  <p><em>(Content providers: see also <a href="https://www.w3.org/WAI/standards-guidelines/wcag/conformance-logos" rel="nofollow">Adding WCAG Conformance Logos</a>.)</em></p>
+  

--- a/content/demo/act-rule.md
+++ b/content/demo/act-rule.md
@@ -3,7 +3,7 @@ title: "HTML page has lang attribute"
 permalink: /writing/supporting-documents/demo-act
 ref: /writing/supporting-documents/demo-act/
 lang: en
-layout: supporting_document
+layout: minimal
 supporting_doc_nav_links:
   - name: All Rules
     ref: /standards-guidelines/act/rules/

--- a/content/demo/coga-pattern.md
+++ b/content/demo/coga-pattern.md
@@ -2,7 +2,7 @@
 title: Use a Consistent Visual Design
 permalink: /writing/supporting-documents/demo-coga
 ref: /writing/supporting-documents/demo-coga/
-layout: supporting_document
+layout: minimal
 type_of_guidance: Pattern        
 supporting_doc_nav_links:
   - name: All Objectives

--- a/content/writing-supporting-docs.md
+++ b/content/writing-supporting-docs.md
@@ -12,9 +12,9 @@ github:
 {% include box.html type="start" title="Summary" class="" %}
 {:/}
 
-**Note: We are changing a few things on this page. Please don't use this yet.**
+At WAI, we sometimes have (sets of) documents that do not require the full WAI website wrapper, but we want them to look like WAI documents. 
 
-<s>At WAI, we sometimes have (sets of) documents that are not naturally part of the WAI website, but we want them to look like WAI documents.</s> These are commonly “supporting documents” for our accessibility standards, like the Techniques and Understanding documents for the Web Content Accessibility Guidelines (WCAG).
+These are commonly “supporting documents” for our accessibility standards, like the Techniques and Understanding documents for the Web Content Accessibility Guidelines (WCAG).
 
 {::nomarkdown}
 {% include box.html type="end" %}
@@ -23,14 +23,12 @@ github:
 
 {% include toc.html %}
 
-**Note: We are changing a few things on this page. Please don't use this yet.**
-
 ## How to use the “supporting documents” layout
 
 In the document's front matter, add:
 
 ```yaml
-layout: supporting_document
+layout: minimal
 ```
 
 ## Other front matter
@@ -84,8 +82,8 @@ The supporting document template displays different sidebars based on the `type_
 
 Currently, specific sidebars are supported for: 
 
-- Pattern (for COGA Design Guide)
-- “Test Rule” (for ACT Rules)
+- `Pattern` - for COGA Design Guide
+- `Test Rule` - for ACT Rules
 
 ## Examples
 


### PR DESCRIPTION
* Use “standalone_resource” as the name for the supporting docs layout: `layout: standalone_resource` applies the supporting docs lay-out
