### PR TITLE
Fix expand/collapse button label to not use a heading

### DIFF
--- a/_components/excol/multiple.md
+++ b/_components/excol/multiple.md
@@ -130,7 +130,7 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit. Eveniet quibusdam aspe
 {:/}
 
 ```html
-{{% include excol.html type="all" %}
+{% include excol.html type="all" %}
 
 {% include excol.html type="start" id="one" %}
 

--- a/_components/excol/single.md
+++ b/_components/excol/single.md
@@ -28,7 +28,7 @@ Standard expand collapse:
 ```liquid
 {%raw%}{% include excol.html type="start" id="optional-id" %}
 
-### Heading
+Expand/collapse button label
 
 {% include excol.html type="middle" %}
 
@@ -55,7 +55,7 @@ Content of the expand/collapse.
 
 {% include excol.html type="start" id="optional-id" %}
 
-### Heading
+Expand/collapse button label
 
 {% include excol.html type="middle" %}
 
@@ -70,7 +70,7 @@ Content of the expand/collapse.
 ```html
 {% include excol.html type="start" id="optional-id" %}
 
-### Heading
+Expand/collapse button label
 
 {% include excol.html type="middle" %}
 


### PR DESCRIPTION
Heading inside a button does not work