### PR TITLE
fix: make HTML video responsive

### DIFF
--- a/_components/images.css
+++ b/_components/images.css
@@ -19,3 +19,8 @@ img {
 
 main img { max-width: 100%; }
 main img:not([width]) { width: var(--img-width); }
+
+main video { 
+  max-width: 100%; 
+  height: auto; 
+}


### PR DESCRIPTION
This is an upstream fix for a downstream issue in the Understanding WCAG reflow page which was causing HTML video to cause two-dimensional scrolling.

- [x] Add `max-width: 100%` and `height: auto` rules to `main video`

Videos with a set `[height]` and `[width]` need both of these rules to maintain intrinsic `aspect-ratio` when resizing.

Original Pull Request: https://github.com/w3c/wcag/pull/3430
Closes https://github.com/w3c/wcag/issues/3401
