### PR TITLE
New _includes for Translations sitemaps

### DIFF
--- a/_includes/t-github-issue.html
+++ b/_includes/t-github-issue.html
@@ -1,6 +1,42 @@
+{%- if include.page.collection -%}{%- assign col = site.collections | where: "label", include.page.collection | first -%}{%- endif- %}
+
+{%- unless include.page.github.hide -%}
+{%- if include.page.github.repository -%}{%- assign repo = page.github.repository -%}{%endif%}
+
+{%- if site.repository -%}
+    {%- assign repo = site.repository -%}
+{%- endif- %}
+{%- if include.page.collection -%}
+    {%- assign repo = col.repository -%}
+{%- endif- %}
+{%- if include.page.github.repository -%}
+    {%- assign repo = include.page.github.repository -%}
+{%- endif- %}
+
+{%- assign branch = "master" -%}
+{%- if site.branch -%}
+    {%- assign branch = site.branch -%}
+{%- endif- %}
+{%- if include.page.collection -%}
+    {%- if col.branch -%}
+    {%- assign branch = col.branch -%}
+    {%- endif -%}
+{%- endif- %}
+{%- if include.page.github.branch -%}
+    {%- assign branch = include.page.github.branch -%}
+{%- endif- %}
+
+{%- assign path = "index.md" -%}
+{%- if include.page.collection -%}
+    {%- assign path = include.page.path -%}
+{%- endif- %}
+{%- if include.page.github.path -%}
+    {%- assign path = include.page.github.path -%}
+{%- endif- %}
+
 I would like to {% if include.status == 'new' %} translate into {{ include.tname }} {% elsif include.status == 'update' %} update the {{ include.tname }} translation of {% endif %} the following resource:
 - Page URL: {{include.page.url | absolute_url}}
-{% if {{original.github.repository}} %}- Github Repository: [{{original.github.repository}}](https://github.com/{{original.github.repository}}){% endif %}
+- Link to file in GitHub: [https://github.com/{{repo}}/edit/{{branch}}/{{path}}](https://github.com/{{repo}}/edit/{{branch}}/{{path}})
 
 I have read the information on Translating WAI Documents at https://www.w3.org/WAI/about/translating/
 

--- a/_includes/t-github-issue.html
+++ b/_includes/t-github-issue.html
@@ -1,8 +1,5 @@
 {%- if include.page.collection -%}{%- assign col = site.collections | where: "label", include.page.collection | first -%}{%- endif- %}
 
-{%- unless include.page.github.hide -%}
-{%- if include.page.github.repository -%}{%- assign repo = page.github.repository -%}{%endif%}
-
 {%- if site.repository -%}
     {%- assign repo = site.repository -%}
 {%- endif- %}
@@ -36,7 +33,8 @@
 
 I would like to {% if include.status == 'new' %} translate into {{ include.tname }} {% elsif include.status == 'update' %} update the {{ include.tname }} translation of {% endif %} the following resource:
 - Page URL: {{include.page.url | absolute_url}}
-- Link to file in GitHub: [https://github.com/{{repo}}/edit/{{branch}}/{{path}}](https://github.com/{{repo}}/edit/{{branch}}/{{path}})
+{% if include.status == 'new' %}- Link to original file in GitHub: [https://github.com/{{repo}}/edit/{{branch}}/{{path}}](https://github.com/{{repo}}/edit/{{branch}}/{{path}}){% endif %}
+{% if include.status == 'update' %}- Link to file in GitHub: [https://github.com/{{repo}}/edit/{{branch}}/{{path}}](https://github.com/{{repo}}/edit/{{branch}}/{{path}}){% endif %}
 
 I have read the information on Translating WAI Documents at https://www.w3.org/WAI/about/translating/
 

--- a/_includes/t-github-issue.html
+++ b/_includes/t-github-issue.html
@@ -1,0 +1,11 @@
+I would like to {% if include.status == 'new' %} translate into {{ include.tname }} {% elsif include.status == 'update' %} update the {{ include.tname }} translation of {% endif %} the following resource:
+- Page URL: {{include.page.url | absolute_url}}
+{% if {{original.github.repository}} %}- Github Repository: [{{original.github.repository}}](https://github.com/{{original.github.repository}}){% endif %}
+
+I have read the information on Translating WAI Documents at https://www.w3.org/WAI/about/translating/
+
+I will wait for confirmation that the resource is ready for translation.
+
+{% if include.status == 'new' %}https://github.com/w3c/wai-translations/labels/initial-translation
+{% elsif include.status == 'update' %}https://github.com/w3c/wai-translations/labels/translation-update
+{% endif %}

--- a/_includes/t-status.html
+++ b/_includes/t-status.html
@@ -1,0 +1,39 @@
+{% assign original=alldocs | where_exp:"item", "item.lang == 'en' or item.lang == nil" | where_exp:"item", "item.ref == include.page.url or item.url == include.page.url" | first %}
+{% assign t=alldocs | where_exp:"item", "item.lang == page.tlang and item.ref == include.page.url" | first %}
+{%- capture page_title -%}
+  {%- if t != nil -%}
+    <a href="{{ t.permalink | relative_url }}"> {{ t.title }} ({{ original.title }})
+  {%- elsif t == nil and original.permalink != nil -%}
+    <a href="{{ original.permalink | relative_url }}">{{ original.title }}
+  {%- elsif t == nil and original.permalink == nil and include.page.name.en != nil -%}
+    <a href="{{ include.page.url | relative_url }}">{{ include.page.name.en }}
+  {%- else -%}
+    <a href="{{ include.page.url | relative_url }}">{{ include.page.name }}
+  {%- endif -%}
+  </a>
+{%- endcapture -%}
+{% capture t-date %}{{t.last_updated | date: '%s' | plus: 0 }}{% endcapture %}
+{% capture en-date %}{{original.last_updated | date: '%s' | plus: 0 }}{% endcapture %}
+{%- capture t_status -%}
+  {%- if t == nil -%}none
+  {%- elsif t.size != 0 and t-date < en-date -%}outdated
+  {%- elsif t.size != 0 and t-date >= en-date -%}uptodate
+  {%- endif -%}
+{%- endcapture -%}
+{% include box.html type="start" title=page_title h=include.h %}
+{%- case t_status -%}
+  {%- when "none" -%}
+    {%- capture issue_body_new | newline_to_br -%}
+      {%- include t-github-issue.html status="new" tname=tlangname page=include.page -%}
+    {%- endcapture -%}
+    <p>{% include_cached icon.html name="ex-circle" %} No translation available</p>
+    <p><a href="https://github.com/w3c/wai-translations/issues/new?title=[{{ tlangname }}]+{{original.title | url_encode}}&body={{issue_body_new | url_encode}}">Volunteer to translate this page</a></p>
+  {%- when "outdated" -%}
+    {%- capture issue_body_update | newline_to_br -%}
+      {%- include t-github-issue.html status="update" tname=tlangname page=include.page -%}
+    {%- endcapture -%}
+    <p><mark>{% include_cached icon.html name="warning" %} Translation needs update</mark><p>
+    <p><a href="https://github.com/w3c/wai-translations/issues/new?title=[{{ tlangname }}]+{{original.title | url_encode}}&body={{issue_body_update | url_encode}}">Volunteer to update the translation</a></p>
+  {%- when "uptodate" -%}
+    <p>{% include_cached icon.html name="check-circle" %} Up-to-date</p>
+{%- endcase -%}

--- a/_includes/t-status.html
+++ b/_includes/t-status.html
@@ -24,13 +24,13 @@
 {%- case t_status -%}
   {%- when "none" -%}
     {%- capture issue_body_new | newline_to_br -%}
-      {%- include t-github-issue.html status="new" tname=tlangname page=include.page -%}
+      {%- include t-github-issue.html status="new" tname=tlangname page=original -%}
     {%- endcapture -%}
     <p>{% include_cached icon.html name="ex-circle" %} No translation available</p>
     <p><a href="https://github.com/w3c/wai-translations/issues/new?title=[{{ tlangname }}]+{{original.title | url_encode}}&body={{issue_body_new | url_encode}}">Volunteer to translate this page</a></p>
   {%- when "outdated" -%}
     {%- capture issue_body_update | newline_to_br -%}
-      {%- include t-github-issue.html status="update" tname=tlangname page=include.page -%}
+      {%- include t-github-issue.html status="update" tname=tlangname page=t -%}
     {%- endcapture -%}
     <p><mark>{% include_cached icon.html name="warning" %} Translation needs update</mark><p>
     <p><a href="https://github.com/w3c/wai-translations/issues/new?title=[{{ tlangname }}]+{{original.title | url_encode}}&body={{issue_body_update | url_encode}}">Volunteer to update the translation</a></p>


### PR DESCRIPTION
Creates new `_includes`:
- `t-status.html` (for translation status): 
  - is used in Translations sitemaps to check if a resource has been translated into a specific language, or if the translated page needs update. 
  - calls `t-github-issue.yml` to prefill a GitHub issue when someone volunteers to create/update a translation.
- `t-github-issue.html` (for translation GitHub issue): 
  - generates a GitHub issue body template with some useful info about the page concerned.
  - is used by `t-status.html`