### PR TITLE
Fix resource-title include

### DIFF
--- a/_includes/resource-title.html
+++ b/_includes/resource-title.html
@@ -1,5 +1,5 @@
 {%- assign resource=site.documents | where: "ref", include.to | where: "lang", include.lang -%}
-{%- unless resource -%}
+{%- unless resource.size > 0 -%}
   {%- assign resource=site.pages | where: "ref", include.to | where: "lang", include.lang -%}
 {%- endunless -%}
 {%- if resource -%}


### PR DESCRIPTION
Fixes https://github.com/w3c/wai-translations/issues/120

### Context

The code intends to find an object with given `ref` and `lang`, by first looking into `site.documents` (all the documents in every collection), then into `site.pages` (pages that are not in a collection).

To do so, it uses an `unless` tag to look into `site.pages` **when** no result is found into `site.documents`.

### Problem

`{%- unless resource -%}` do not work as intended. In Liquid, an array, even when empty, is truthy (see https://shopify.github.io/liquid/basics/truthy-and-falsy/). The condition is always met and the block of code is never executed. 


### Solution

`{%- unless resource.size > 0 -%}` is used to properly check if the array is empty. The block of code is executed when expected. See https://shopify.github.io/liquid/filters/size/