### PR TITLE
Footnote: support Japanese

### DIFF
--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -444,11 +444,19 @@ if (document.querySelector('main')) {
       element.setAttribute('title',      t('to footnote') + ' ' + element.textContent);
     });
 
+    let pageLang = document.documentElement.lang || document.getElementsByTagName('html')[0].getAttribute('xml:lang');
+
     var footnoteBackLinks = footnoteBox.querySelectorAll('a.reversefootnote');
 
     Array.prototype.forEach.call(footnoteBackLinks, function(element, i){
-      element.setAttribute('aria-label', t('back to footnote') + ' ' + element.getAttribute('href').replace('#fnref:','') + ' ' + t('in text'));
-      element.setAttribute('title',      t('back to footnote') + ' ' + element.getAttribute('href').replace('#fnref:','') + ' ' + t('in text'));
+      if (pageLang === "ja") {
+        element.setAttribute('aria-label', t('in text') + ' ' + element.getAttribute('href').replace('#fnref:', '') + ' ' + t('back to footnote'));
+        element.setAttribute('title',      t('in text') + ' ' + element.getAttribute('href').replace('#fnref:','') + ' ' + t('back to footnote'));
+      }
+      else {
+        element.setAttribute('aria-label', t('back to footnote') + ' ' + element.getAttribute('href').replace('#fnref:', '') + ' ' + t('in text'));
+        element.setAttribute('title',      t('back to footnote') + ' ' + element.getAttribute('href').replace('#fnref:','') + ' ' + t('in text'));
+      }
     });
 
   }

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -444,18 +444,20 @@ if (document.querySelector('main')) {
       element.setAttribute('title',      t('to footnote') + ' ' + element.textContent);
     });
 
-    let pageLang = document.documentElement.lang || document.getElementsByTagName('html')[0].getAttribute('xml:lang');
+    const pageLang = document.documentElement.lang || document.getElementsByTagName('html')[0].getAttribute('xml:lang');
 
     var footnoteBackLinks = footnoteBox.querySelectorAll('a.reversefootnote');
 
     Array.prototype.forEach.call(footnoteBackLinks, function(element, i){
+      const footnoteIndex = element.getAttribute('href').replace('#fnref:', '')
+
       if (pageLang === "ja") {
-        element.setAttribute('aria-label', t('in text') + ' ' + element.getAttribute('href').replace('#fnref:', '') + ' ' + t('back to footnote'));
-        element.setAttribute('title',      t('in text') + ' ' + element.getAttribute('href').replace('#fnref:','') + ' ' + t('back to footnote'));
+        element.setAttribute('aria-label', t('in text') + ' ' + footnoteIndex + ' ' + t('back to footnote'));
+        element.setAttribute('title',      t('in text') + ' ' + footnoteIndex + ' ' + t('back to footnote'));
       }
       else {
-        element.setAttribute('aria-label', t('back to footnote') + ' ' + element.getAttribute('href').replace('#fnref:', '') + ' ' + t('in text'));
-        element.setAttribute('title',      t('back to footnote') + ' ' + element.getAttribute('href').replace('#fnref:','') + ' ' + t('in text'));
+        element.setAttribute('aria-label', t('back to footnote') + ' ' + footnoteIndex + ' ' + t('in text'));
+        element.setAttribute('title',      t('back to footnote') + ' ' + footnoteIndex + ' ' + t('in text'));
       }
     });
 


### PR DESCRIPTION
**Context:** When users read a [footnote](https://wai-website-theme.netlify.app/components/footnotes/) at the bottom of a page, a link allows them to go back to the occurence of the footnote in the text.

The link is displayed as an arrow, with the following text as `title` & `aria-label`: "back to footnote 1 in text"

**Issue:** In Japanese, "in text" should be said first. See context in https://github.com/w3c/wai-website-data/pull/124#discussion_r1486353183

**Resolution:** This PR switches the order of the UI terms when the page is in Japanese.