### PR TITLE
Video Card Component – Fix the lang label

### DIFF
--- a/_components/video-card.md
+++ b/_components/video-card.md
@@ -58,7 +58,7 @@ It is possible to concatenate multiple sets of those subtitles using commas. See
 
 {% include video-card.html
     video-url="//media.w3.org/wai/evaluation-intros/conformance-evaluation.mp4"
-    captions="//media.w3.org/wai/evaluation-intros/conformance-evaluation-cc.srt|en"
+    captions="/wai-videos/evaluating/conformance-evaluation.en.vtt|en|default"
     accessible-version="https://www.w3.org/WAI/test-evaluate/conformance/"
     accessible-version-label="Video: Conformance Evaluation"
 %}

--- a/_includes/video-card.html
+++ b/_includes/video-card.html
@@ -6,6 +6,7 @@
   {% endif %}
     <source src="{{ include.video-url }}" type="video/mp4">
     {%- assign captions = include.captions | split: ',' -%}
+    {%- assign langs = site.data.lang -%}
     {%- for caption in captions -%}
       {%- assign c = caption | split: '|' -%}
       {%- assign clangcode = c[1] -%}


### PR DESCRIPTION
Fixed issue spotted in https://github.com/w3c/wai-people-use-web/pull/113: in the video card component, the Captions/Subtitles language name derives from the `langs` variable. But this variable was not assigned any value.

Hence, "en" was displayed instead of "English".

The behaviour is correct in https://www.w3.org/WAI/test-evaluate/ because a "video-player-data" component (that initializes this variable) was used <ins>before</ins> the video card components.

---

This PR also updates the Video Card Design Component example, to use a correctly formatted WebVTT file.