### PR TITLE
Fix path in image.html

### DIFF
--- a/_includes/image.html
+++ b/_includes/image.html
@@ -1,5 +1,5 @@
 {%- assign repo = page.github.repository | replace: "w3c/", "" -%}
-{%- if repo != "wai-website" -%}
+{%- if repo and repo != '' -%}
 {%- assign path = "/" | prepend: repo | prepend: "/content-images/" | relative_url -%}
 {%- else -%}
 {%- assign path = "/content-images/" | relative_url -%}

--- a/_includes/image.html
+++ b/_includes/image.html
@@ -1,5 +1,5 @@
+{%- if page.github.repository -%}
 {%- assign repo = page.github.repository | replace: "w3c/", "" -%}
-{%- if repo and repo != '' -%}
 {%- assign path = "/" | prepend: repo | prepend: "/content-images/" | relative_url -%}
 {%- else -%}
 {%- assign path = "/content-images/" | relative_url -%}


### PR DESCRIPTION
Resolves https://github.com/w3c/wai-website/issues/829

## Expected behaviour

- When the resource is _not_ developed in the main `wai-website` repo, the image src should be prepended with `/content-images/{name of the repo}/`
- Else, the image src should be prepended with `/content-images/`

## Current behaviour

- When the resource is _not_ developed in the main `wai-website` repo, the image src is prepended with `/content-images/{name of the repo}/`: OK ✅ 
- When the resource is developed in the main `wai-website` repo, the image src is prepended with `/content-images//`: Not OK ❌ 

## Source of the problem

```
{%- assign repo = page.github.repository | replace: "w3c/", "" -%}
{%- if repo != "wai-website" -%}
{%- assign path = "/" | prepend: repo | prepend: "/content-images/" | relative_url -%}
{%- else -%}
{%- assign path = "/content-images/" | relative_url -%}
{%- endif -%}
```

- Since `wai-website` is the default repository, the `github.repository` variable is no longer used for resources developed in `wai-website` repo.
- `{%- if repo != "wai-website" -%}` was always truthy (see https://shopify.github.io/liquid/basics/truthy-and-falsy/)

## Solution

```
{%- if page.github.repository -%}
{%- assign repo = page.github.repository | replace: "w3c/", "" -%}
{%- assign path = "/" | prepend: repo | prepend: "/content-images/" | relative_url -%}
{%- else -%}
{%- assign path = "/content-images/" | relative_url -%}
{%- endif -%}
```