### PR TITLE
Name default branch "main"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ The theme is documented at https://wai-website-theme.netlify.app/ along with ins
 
 Since @@ 2024, the default branch is named `main`, for consistency with other W3C repositories and [GitHub default branch name](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches#about-the-default-branch).
 
-If have an existing fork, you can [rename your fork's default branch](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch#renaming-a-branch).
+If you have an existing fork, you can [rename your fork's default branch](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch#renaming-a-branch).
 
 If you have a local clone, you can either delete and re-clone the repository, or update it by [running the commands from GitHub documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch#updating-a-local-clone-after-a-branch-name-changes).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The theme is documented at https://wai-website-theme.netlify.app/ along with ins
 
 ### The default branch name has changed. How to update my fork?
 
-Since @@ 2024, the default branch is named `main`, for consistency with other W3C repositories and [GitHub default branch name](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches#about-the-default-branch).
+Since 4 September 2024, the default branch is named `main`, for consistency with other W3C repositories and [GitHub default branch name](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches#about-the-default-branch).
 
 If you have an existing fork, you can [rename your fork's default branch](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch#renaming-a-branch).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
+# Web Accessibility Initiative's Website Theme
+
+This repository is where the Jekyll theme for [w3.org/WAI](https://www.w3.org/WAI/) lives.
+
+The components are included in all Jekyll sites that make up the WAI website. Their CSS is also used by tools built outside Jekyll, like the [ATAG Report Tool](https://www.w3.org/WAI/atag/report-tool/).
+
+## Documentation
+
+The theme is documented at https://wai-website-theme.netlify.app/ along with instructions for creating and editing documents.
+
 [![Netlify Status](https://api.netlify.com/api/v1/badges/bccece24-1280-4687-8121-4536666ea4c9/deploy-status)](https://app.netlify.com/sites/wai-website-theme/deploys)
 
-This repository is where the Jekyll theme for w3.org/WAI lives.
+## FAQ
 
-The components are included in all of the many Jekyll sites that make up the WAI website. Their CSS is also used by tools built outside Jekyll, like the [ATAG Report Tool](https://www.w3.org/WAI/atag/report-tool/).
+### The default branch name has changed. How to update my fork?
+
+Since @@ 2024, the default branch is named `main`, for consistency with other W3C repositories and [GitHub default branch name](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches#about-the-default-branch).
+
+If have an existing fork, you can [rename your fork's default branch](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch#renaming-a-branch).
+
+If you have a local clone, you can either delete and re-clone the repository, or update it by [running the commands from GitHub documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch#updating-a-local-clone-after-a-branch-name-changes).

--- a/_components/icons.md
+++ b/_components/icons.md
@@ -62,7 +62,7 @@ inline_css: |
 {% include box.html type="start" title="Overview" class="" %}
 {:/}
 
-Icons can be used in various ways with the `icon.html` helper. <a href="https://github.com/w3c/wai-website-theme/blob/master/assets/images/icons.svg">The icons are in SVG format in a single sprite file.</a>
+Icons can be used in various ways with the `icon.html` helper. <a href="https://github.com/w3c/wai-website-theme/blob/main/assets/images/icons.svg">The icons are in SVG format in a single sprite file.</a>
 
 {::nomarkdown}
 {% include box.html type="end" %}

--- a/_config.yml
+++ b/_config.yml
@@ -6,10 +6,9 @@
 # 'jekyll serve'. If you change this file, please restart the server process.
 
 # Site settings
-title: "Web Accessibility Initiative (WAI)"
-email: your-email@domain.com
+title: "Web Accessibility Initiative (WAI)'s Website Theme"
 description: > # this means to ignore newlines until "baseurl:"
-  The Website of the World Wide Web Consortium’s Web Accessibility Initiative.
+  Learn more about the theme of the Web Accessibility Initiative's website.
 baseurl: "/wai-website-theme" # the subpath of your site, e.g. /blog
 url: "https://w3c.github.io" # the base hostname & protocol for your site
 twitter:
@@ -22,6 +21,8 @@ exclude:
   - "README.md"
   - "w3c.json"
   - "node_modules"
+repository: w3c/wai-website-theme
+branch: main
 
 # Build settings
 markdown: kramdown
@@ -30,7 +31,6 @@ kramwdown:
   input: GFM
   syntax_highlighter: rouge
 highlighter: rouge
-repository: w3c/wai-website-theme
 
 ytkey: AIzaSyCiZ9uToWu9jb7BTx47NtzCvmGGXKXp8nI
 
@@ -41,7 +41,6 @@ collections:
     area: "Design Components"
     name: "Components"
     shortname: "Components"
-    repository: w3c/wai-website-theme
     output: true
     acknowledgements: false
     permalink: /:collection/:path/

--- a/content/workflow.md
+++ b/content/workflow.md
@@ -81,7 +81,7 @@ WAI website components:
 
 * [https://github.com/w3c/wai-website-theme/](https://github.com/w3c/wai-website-theme/) - Jekyll theme - includes components and layouts as well as docs
 * [https://wai-website-theme.netlify.app/components/](https://wai-website-theme.netlify.app/components/) - descriptions of design components
-* [https://github.com/w3c/wai-website-theme/blob/master/_layouts/standalone_resource.html](https://github.com/w3c/wai-website-theme/blob/master/_layouts/standalone_resource.html) - layout for new minimal resources - used for report tools, supplemental guidance, ACT Rules, ARIA APG
+* [https://github.com/w3c/wai-website-theme/blob/main/_layouts/standalone_resource.html](https://github.com/w3c/wai-website-theme/blob/main/_layouts/standalone_resource.html) - layout for new minimal resources - used for report tools, supplemental guidance, ACT Rules, ARIA APG
   * as described in [https://github.com/w3c/wai-minimal-header-design/](https://github.com/w3c/wai-minimal-header-design/)
 
 Currently, issues related to these components are in different places. We are in the process of moving all issues to: [https://github.com/w3c/wai-website/issues/](https://github.com/w3c/wai-website/issues/) so they are in one place. We will use labels to group them.

--- a/content/writing-frontmatter.md
+++ b/content/writing-frontmatter.md
@@ -322,7 +322,7 @@ to provide the fork and edit this document on GitHub links.
 ```yaml
 github:
   repository: w3c/wai-repository
-  branch: master
+  branch: main
   path: 'index.md'
 ```
 

--- a/content/writing-standalone-resources.md
+++ b/content/writing-standalone-resources.md
@@ -164,7 +164,7 @@ sidebar: true
 
 ## Tools that do not use the WAI Website Theme
 
-Some tools &mdash; currently WCAG-EM Report Tool and ATAG Report Tool &mdash; do not use the WAI website theme. Instead they are implemented in other technologies and linked into the WAI website via W3C redirects. They use the Tool version of the [Minimal Header](https://github.com/w3c/wai-website-theme/blob/master/_includes/minimal-header.html) and use the theme styles, including those for the [Minimal Header](https://github.com/w3c/wai-website-theme/blob/master/_components/minimal-header.css) for visual consistency with the WAI website.
+Some tools &mdash; currently WCAG-EM Report Tool and ATAG Report Tool &mdash; do not use the WAI website theme. Instead they are implemented in other technologies and linked into the WAI website via W3C redirects. They use the Tool version of the [Minimal Header](https://github.com/w3c/wai-website-theme/blob/main/_includes/minimal-header.html) and use the theme styles, including those for the [Minimal Header](https://github.com/w3c/wai-website-theme/blob/main/_components/minimal-header.css) for visual consistency with the WAI website.
 
 ### Tool navigation, depreciated
 


### PR DESCRIPTION
For consistency: new GitHub repos use `main` as default branch name and most W3C repos now use `main`.

Description of this pull request:
- Add instructions for forked repositories/local clones in README
- Update _config.yml to make "Fork & Edit" links work
- Update references in documentation