### PR TITLE
Remove email subject in “Help improve this page” and improve component performance

### DIFF
--- a/_includes/feedback-box.html
+++ b/_includes/feedback-box.html
@@ -1,13 +1,13 @@
 {%- capture helptitle -%}{% include_cached t.html t="Help improve this page" lang=page.lang %}{%- endcapture -%}
 {%- assign feedbackmail = page.feedbackmail | default: "wai@w3.org"-%}
 {% assign reppattern = "$1|" | append: feedbackmail%}
-{%- capture helpdesc -%}{% include t.html t="Please share your ideas, suggestions, or comments via e-mail to the publicly-archived list [$1](mailto:$1$2) or via GitHub." replace=reppattern %}{%- endcapture -%}
+{%- capture helpdesc -%}{% include_cached t.html t="Please share your ideas, suggestions, or comments via e-mail to the publicly-archived list [$1](mailto:$1$2) or via GitHub." replace=reppattern lang=page.lang %}{%- endcapture -%}
 {%- capture mailbody -%}
 {% include_cached t.html t="[include a relevant email Subject]" lang=page.lang hideTranslationHints=true %}
 
 {% include_cached t.html t="[put comment here...]" lang=page.lang hideTranslationHints=true %}
 
-{% if feedbackmail == "wai@w3.org" %}{% include t.html t="I give permission to share this to a publicly-archived e-mail list." lang=page.lang hideTranslationHints=true %}{% endif %}
+{% if feedbackmail == "wai@w3.org" %}{% include_cached t.html t="I give permission to share this to a publicly-archived e-mail list." lang=page.lang hideTranslationHints=true %}{% endif %}
 {%- endcapture -%}
 {%- assign mailbody = mailbody | url_encode | replace: "+", "%20" -%}
 {%- assign mailparams = "?body=" | append: mailbody -%}

--- a/_includes/feedback-box.html
+++ b/_includes/feedback-box.html
@@ -3,11 +3,11 @@
 {% assign reppattern = "$1|" | append: feedbackmail%}
 {%- capture helpdesc -%}{% include_cached t.html t="Please share your ideas, suggestions, or comments via e-mail to the publicly-archived list [$1](mailto:$1$2) or via GitHub." replace=reppattern lang=page.lang %}{%- endcapture -%}
 {%- capture mailbody -%}
-{% include_cached t.html t="[include a relevant email Subject]" lang=page.lang hideTranslationHints=true %}
+{% include_cached t.html t="[include a relevant email Subject]" lang=page.lang plainText=true hideTranslationHints=true %}
 
-{% include_cached t.html t="[put comment here...]" lang=page.lang hideTranslationHints=true %}
+{% include_cached t.html t="[put comment here...]" lang=page.lang plainText=true hideTranslationHints=true %}
 
-{% if feedbackmail == "wai@w3.org" %}{% include_cached t.html t="I give permission to share this to a publicly-archived e-mail list." lang=page.lang hideTranslationHints=true %}{% endif %}
+{% if feedbackmail == "wai@w3.org" %}{% include_cached t.html t="I give permission to share this to a publicly-archived e-mail list." lang=page.lang plainText=true hideTranslationHints=true %}{% endif %}
 {%- endcapture -%}
 {%- assign mailbody = mailbody | url_encode | replace: "+", "%20" -%}
 {%- assign mailparams = "?body=" | append: mailbody -%}

--- a/_includes/feedback-box.html
+++ b/_includes/feedback-box.html
@@ -1,40 +1,28 @@
-{%- if page.collection -%}{%- assign col = site.collections | where: "label", page.collection | first -%}{%- endif- %}
-{%- capture helptitle -%}{% include t.html t="Help improve this page" %}{%- endcapture -%}
-{%- if page.feedbackmail -%}
-  {%- assign feedbackmail = page.feedbackmail -%}
-{%- else -%}
-  {%- assign feedbackmail = "wai@w3.org" -%}
-{%- endif -%}
+{%- capture helptitle -%}{% include_cached t.html t="Help improve this page" lang=page.lang %}{%- endcapture -%}
+{%- assign feedbackmail = page.feedbackmail | default: "wai@w3.org"-%}
 {% assign reppattern = "$1|" | append: feedbackmail%}
 {%- capture helpdesc -%}{% include t.html t="Please share your ideas, suggestions, or comments via e-mail to the publicly-archived list [$1](mailto:$1$2) or via GitHub." replace=reppattern %}{%- endcapture -%}
-
-{%- if page.lang -%}
-    {%- assign mailsubject = "[" | append: page.lang | append: "] " | append: page.title | url_encode | replace: "+", "%20" -%}
-{%- else -%}
-    {%- assign mailsubject = page.title | url_encode | replace: "+", "%20" -%}
-{%- endif -%}
-
 {%- capture mailbody -%}
-{% include t.html t="[put comment here...]" %}
+{% include_cached t.html t="[include a relevant email Subject]" lang=page.lang hideTranslationHints=true %}
 
-{% if feedbackmail == "wai@w3.org" %}{% include t.html t="I give permission to share this to a publicly-archived e-mail list." %}{% endif %}
+{% include_cached t.html t="[put comment here...]" lang=page.lang hideTranslationHints=true %}
+
+{% if feedbackmail == "wai@w3.org" %}{% include t.html t="I give permission to share this to a publicly-archived e-mail list." lang=page.lang hideTranslationHints=true %}{% endif %}
 {%- endcapture -%}
 {%- assign mailbody = mailbody | url_encode | replace: "+", "%20" -%}
-
-{%- assign mailparams = "?subject=" | append: mailsubject | append: "&body=" | append: mailbody -%}
-
-{%- include box.html type="start" title=helptitle h=2 class="icon space-above" icon="comments" id="helpimprove" aria_label="feedback" -%}
+{%- assign mailparams = "?body=" | append: mailbody -%}
+{%- include_cached box.html type="start" title=helptitle h=2 class="icon space-above" icon="comments" id="helpimprove" aria_label="feedback" -%}
 
 {{ helpdesc | replace: "$2", mailparams | markdownify -}}
 
 <div class="button-group">
-    <a href="{{ "mailto:" | append: feedbackmail | append: mailparams }}" class="button"><span>{% include t.html t="E-mail" %}</span></a>
+    <a href="{{ "mailto:" | append: feedbackmail | append: mailparams }}" class="button"><span>{% include_cached t.html t="E-mail" lang=page.lang %}</span></a>
     {%- unless page.github.hide -%}
     {%- capture github-file-path -%}{% include_cached github-file-path.html p=page %}{%- endcapture -%}
-    <a href="{{ github-file-path }}" class="button"><span>{% include t.html t="Fork &amp; Edit on GitHub" %}</span></a>
+    <a href="{{ github-file-path }}" class="button"><span>{% include_cached t.html t="Fork &amp; Edit on GitHub" lang=page.lang %}</span></a>
     {%- comment -%}<a href="https://github.com/{{repo}}/issues" class="button"><span>List of GitHub Issues</span></a>{%- endcomment -%}
-    <a href="https://github.com/{{repo}}/issues/new?template=content-issue.yml{%- unless page.lang == 'en' -%}&title={{ "[" | append: page.lang | append: "] " | uri_escape }}{%- endunless -%}{%- if page.github.label -%}&wai-resource-id={{page.github.label}}{%- endif -%}&wai-url={{page.url | absolute_url | uri_escape }}" class="button"><span>{% include t.html t="New GitHub Issue" %}</span></a>
+    <a href="https://github.com/{{repo}}/issues/new?template=content-issue.yml{%- unless page.lang == 'en' -%}&title={{ "[" | append: page.lang | append: "] " | uri_escape }}{%- endunless -%}{%- if page.github.label -%}&wai-resource-id={{page.github.label}}{%- endif -%}&wai-url={{page.url | absolute_url | uri_escape }}" class="button"><span>{% include_cached t.html t="New GitHub Issue" lang=page.lang %}</span></a>
     {%- endunless -%}
 </div>
 
-{%- include box.html type="end" -%}
+{%- include_cached box.html type="end" -%}

--- a/_includes/t.html
+++ b/_includes/t.html
@@ -20,7 +20,11 @@
     {%- assign phrase=source[pagelang] -%}
   {%- else -%}
     {%- unless site.hideTranslationHints or include.hideTranslationHints or site.published == true %}<mark lang="en">Needs Translation</mark> {% endunless -%}
-    {%- assign phrase=include.t | prepend: '<span lang="en">' | append: '</span>' -%}
+    {%- unless include.plainText %}
+      {%- assign phrase=include.t | prepend: '<span lang="en">' | append: '</span>' -%}
+    {%- else %}
+      {%- assign phrase=include.t -%}
+    {% endunless -%}
   {%- endif -%}
   {%- if include.replace -%}
     {%- assign replacements = include.replace | split: "||" -%}


### PR DESCRIPTION
Direct link to preview: https://deploy-preview-115--wai-website-theme.netlify.app/components/teasers/

Currently, an email subject is automatically populated when clicking on email links in “Help improve this page”. See for example the [“Help improve this page” section in “Accessibility Fundamentals Overview”](https://www.w3.org/WAI/fundamentals/#helpimprove).

To help with spam processing, this pull request:
- stops populating the email subject
- adds `[include a relevant email Subject]` to the email body, to encourage users to manually add an email subjet.

Resolves https://github.com/w3c/wai-website/issues/941

I have applied additional improvements to the component:
- Removed the line creating a `col` variable: deprecated since bbade4cdd12e5599219e010c24a13dafe97bdef6
- Used [`default` filter](https://shopify.github.io/liquid/filters/default/) to set a default value for `feedbackmail`, instead of if/else statements.
- Cached `t.html` and `box.html` includes. To make it work, I have explicitly passed the page language as argument. (See [Jekyll Include Cache README](https://github.com/benbalter/jekyll-include-cache?tab=readme-ov-file#readme))
- Introduced a `plainText` argument that can be passed to an `t.html` include. When present, `<span lang="en"></span>` is not added around the English text when a translation is missing. Currently, the HTML code was added to the email body...

  Example:

  ```
  <span lang="en">[include a relevant email Subject]</span>

  [votre commentaire ici...]

  J’accepte que ceci soit partagé sur une liste de diffusion archivée publiquement.
  ```

## Test

I built the site before and after the edits: no unexpected changes.

## Impact on Render Stats (using `--profile` flag)

Before caching `t.html` and `box.html` includes:

| Filename | Count |     Bytes |   Time |
|----------|-------|----------|-------|
| jekyll-remote-theme-20241105-81016-1uqh35/_includes/t.html                    | 12667 |   534.87K |  0.652 |
| jekyll-remote-theme-20241105-81016-1uqh35/_includes/box.html                  |  5272 |   726.19K |  0.167 |
| jekyll-remote-theme-20241105-81016-1uqh35/_includes/feedback-box.html         |  1106 |  1470.27K |  1.105 |

After caching `t.html` and `box.html` includes:

| Filename | Count |     Bytes |   Time |
|----------|-------|----------|-------|
| jekyll-remote-theme-20241105-82502-d57quu/_includes/t.html                    |  5754 |   231.31K |  0.383 |
| jekyll-remote-theme-20241105-82502-d57quu/_includes/box.html                  |  3075 |   331.72K |  0.078 |
| jekyll-remote-theme-20241105-82502-d57quu/_includes/feedback-box.html         |  1106 |  1431.32K |  0.492 |