### PR TITLE
Remove use of ytkey (deprecated)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,8 +32,6 @@ kramwdown:
   syntax_highlighter: rouge
 highlighter: rouge
 
-ytkey: AIzaSyCiZ9uToWu9jb7BTx47NtzCvmGGXKXp8nI
-
 # remote_theme: w3c/wai-website-theme
 
 collections:

--- a/_includes/video-player-data.html
+++ b/_includes/video-player-data.html
@@ -60,13 +60,6 @@
 <script src="//ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 <script src="//cdn.jsdelivr.net/npm/js-cookie@3.0.1/dist/js.cookie.min.js"></script>
 <script src="{{ '/assets/ableplayer/build/ableplayer.min.js' | relative_url }}"></script>
-<script>
-    var youTubeDataAPIKey = "{{ site.ytkey }}";
-    var googleApiReady = false;
-    function initGoogleClientApi() {
-        googleApiReady = true;
-    }
-</script>
 <script src="//apis.google.com/js/client.js?onload=initGoogleClientApi"></script>
 
 <script>

--- a/_includes/video-player.html
+++ b/_includes/video-player.html
@@ -56,14 +56,6 @@
 <script src="//ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 <script src="//cdn.jsdelivr.net/npm/js-cookie@3.0.1/dist/js.cookie.min.js"></script>
 <script src="{{ "/assets/ableplayer/build/ableplayer.min.js" | relative_url }}"></script>
-<script>
-  var youTubeDataAPIKey = "{{site.ytkey}}";
-  var googleApiReady = false;
-  function initGoogleClientApi() {
-    googleApiReady = true;
-  }
-</script>
-<script src="//apis.google.com/js/client.js?onload=initGoogleClientApi"></script>
 
 <script>
 (function () {

--- a/_includes/video-playlist.html
+++ b/_includes/video-playlist.html
@@ -122,14 +122,6 @@ The first transcript should be `display: block`. All others should be `display: 
 <script src="//ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 <script src="//cdn.jsdelivr.net/npm/js-cookie@3.0.1/dist/js.cookie.min.js"></script>
 <script src="{{ "/assets/ableplayer/build/ableplayer.min.js" | relative_url }}"></script>
-<script>
-  var youTubeDataAPIKey = "{{site.ytkey}}";
-  var googleApiReady = false;
-  function initGoogleClientApi() {
-    googleApiReady = true;
-  }
-</script>
-<script src="//apis.google.com/js/client.js?onload=initGoogleClientApi"></script>
 
 <script>
 (function () {


### PR DESCRIPTION
For some time, the [AblePlayer](https://github.com/ableplayer) video player used on WAI website was relying on the YouTube Data API to retrieve caption tracks. This API requires a YouTube API Key.

Since v4.4, AblePlayer uses the YouTube Iframe Player API that does not require an API key (see https://github.com/ableplayer/ableplayer/commit/2ab4fac434a3ff1c7b6b3ea1b7301e35bc305799)

The version used on WAI website is 4.5.

This PR removes the deprecated use of a YouTube API Key.