### PR TITLE
Update draft-banner component with feedback from AG Backlog TF

### DIFF
--- a/_components/draft-banner.md
+++ b/_components/draft-banner.md
@@ -8,7 +8,7 @@ inline_css: |
 
 This is the publication warning that appears on the top of unpublished documents:
 
-<section class="default-grid info" tabindex="0">
+<section class="default-grid info" aria-label="Notice">
   <p class="inner">
     This is an unpublished draft preview that might include content that is not yet approved. The published website is at <a href="https://www.w3.org/WAI/">w3.org/WAI/</a>.
   </p>


### PR DESCRIPTION
This is based on a [similar revision](https://github.com/w3c/wcag/pull/4445/commits/8682392903f85a48926fd68092fc7ec0b3c9b5da) advised on last week's Backlog TF call, when I was adding the same draft banner to GitHub Pages deployments and PR previews for WCAG 2.