### PR TITLE
Change WCAG 2.1 Quickref links to WCAG 2.2 Quickref links

### DIFF
--- a/_includes/resources.html
+++ b/_includes/resources.html
@@ -4,7 +4,7 @@
   <p><strong>Success Criteria:</strong></p>
   <ul>
     {%- for sc in site.data.wcag-legacy -%}
-    {%- if page.wcag_success_criteria contains sc.key -%}<li><a href="https://www.w3.org/WAI/WCAG22/quickref/#qr-{{sc.slug}}"><strong>{{sc.key}}</strong> {{sc.title}}:</a> {{sc.desc}} (Level&nbsp;{{sc.level}})</li>{%- endif -%}
+    {%- if page.wcag_success_criteria contains sc.key -%}<li><a href="https://www.w3.org/WAI/WCAG22/quickref/#{{sc.slug}}"><strong>{{sc.key}}</strong> {{sc.title}}:</a> {{sc.desc}} (Level&nbsp;{{sc.level}})</li>{%- endif -%}
     {%- endfor -%}
   </ul>
 {% endif %}

--- a/_includes/resources.html
+++ b/_includes/resources.html
@@ -4,7 +4,7 @@
   <p><strong>Success Criteria:</strong></p>
   <ul>
     {%- for sc in site.data.wcag-legacy -%}
-    {%- if page.wcag_success_criteria contains sc.key -%}<li><a href="https://www.w3.org/WAI/WCAG21/quickref/#qr-{{sc.slug}}"><strong>{{sc.key}}</strong> {{sc.title}}:</a> {{sc.desc}} (Level&nbsp;{{sc.level}})</li>{%- endif -%}
+    {%- if page.wcag_success_criteria contains sc.key -%}<li><a href="https://www.w3.org/WAI/WCAG22/quickref/#qr-{{sc.slug}}"><strong>{{sc.key}}</strong> {{sc.title}}:</a> {{sc.desc}} (Level&nbsp;{{sc.level}})</li>{%- endif -%}
     {%- endfor -%}
   </ul>
 {% endif %}


### PR DESCRIPTION
Fixes 
- w3c/wai-website#1960