### PR TITLE
list-submission-form: use separate server for local form submission

### DIFF
--- a/_includes/list-submission-form.liquid
+++ b/_includes/list-submission-form.liquid
@@ -14,8 +14,10 @@
         success - url to redirect to when succeeded - requiured
         failure - url to redirect to when failed - required
         repository - repository containing the action - required
-        DEBUG_FUNCTION - pass DEBUG to submission function, causes function to return JSON rather than submitting to GitHub
-        DEBUG_USE_LOCAL_FUNCTION - use local/domain function rather than live one exposed by Netlify wai-website deploy
+        DEBUG_SUBMISSION_FUNCTION - pass DEBUG to submission function, causes function to return JSON rather than submitting to GitHub
+        DEBUG_USE_LOCAL_SUBMISSION_FUNCTION - use local/domain function rather than live one exposed by Netlify wai-website deploy
+          - This is intended to be used together with running `node _functions/list-submission.js` in wai-website
+          - Note these two DEBUG_* parameters are independent; you may want to set both for testing
 
       end - end of form
 
@@ -24,7 +26,7 @@
 {%- if include.type == 'start' -%}
 
   {%- if include.DEBUG_USE_LOCAL_SUBMISSION_FUNCTION -%}
-    {% assign action = "/.netlify/functions/list-submission" %}
+    {% assign action = "http://localhost:8000/" %}
   {%- elsif include.action == nil -%}
     {% assign action = "https://wai-website.netlify.app/.netlify/functions/list-submission" %}
   {% else %}


### PR DESCRIPTION
This complements the code that was added at the bottom of `list-submission.js` in https://github.com/w3c/wai-website/pull/2067, to point to a separate local server when `DEBUG_USE_LOCAL_SUBMISSION_FUNCTION` is used. (I'm unsure if the previous setup was actually feasible, given that we typically run the site locally using Jekyll, which definitely cannot meaningfully serve the function endpoint under `.netlify`.)

This also adds more comments below the existing documentation for the two `DEBUG` parameters about how to debug locally, and how the two do not overlap.