### PR TITLE
Update to versions of actions that support Node.js 24

### DIFF
--- a/.github/workflows/compress-images.yml
+++ b/.github/workflows/compress-images.yml
@@ -5,7 +5,7 @@ jobs:
     name: calibreapp/image-actions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: calibreapp/image-actions
         uses: docker://calibreapp/github-image-actions
         env:


### PR DESCRIPTION
Related to https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/