### PR TITLE
list-submission-form: Add non-interactive Cloudflare turnstile widget

### DIFF
--- a/_includes/list-submission-form.liquid
+++ b/_includes/list-submission-form.liquid
@@ -38,16 +38,12 @@
     {% assign method = include.method %}
   {% endif -%}
 
-  {%- if site.env.WAI_LIVE_SITE or site.env.NETLIFY -%}
-    {%- assign turnstile_sitekey = "0x4AAAAAADrGl49RsUW31TYC" -%}
-  {%- else -%}
-    {%- assign turnstile_sitekey = "1x00000000000000000000AA" -%}
-  {%- endif -%}
-
   {% if site.env.WAI_LIVE_SITE %}
-    {%assign WAI_REFERRER_HACK = "/WAI"%}
+    {%- assign turnstile_sitekey = "0x4AAAAAADrGl49RsUW31TYC" -%}
+    {%- assign WAI_REFERRER_HACK = "/WAI" -%}
   {%else%}
-    {%assign WAI_REFERRER_HACK = ""%}
+    {%- assign turnstile_sitekey = "1x00000000000000000000AA" -%}
+    {%- assign WAI_REFERRER_HACK = "" -%}
   {%endif%}
 
   {% capture args %}

--- a/_includes/list-submission-form.liquid
+++ b/_includes/list-submission-form.liquid
@@ -38,6 +38,12 @@
     {% assign method = include.method %}
   {% endif -%}
 
+  {%- if site.env.WAI_LIVE_SITE or site.env.NETLIFY -%}
+    {%- assign turnstile_sitekey = "0x4AAAAAADrGl49RsUW31TYC" -%}
+  {%- else -%}
+    {%- assign turnstile_sitekey = "1x00000000000000000000AA" -%}
+  {%- endif -%}
+
   {% if site.env.WAI_LIVE_SITE %}
     {%assign WAI_REFERRER_HACK = "/WAI"%}
   {%else%}
@@ -61,6 +67,8 @@
 
 {%- elsif include.type == 'end' -%}
 
+  <div class="cf-turnstile" data-sitekey="{{ turnstile_sitekey }}" data-theme="light"></div>
   {%- include html-form.liquid type="end" -%}
+  <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
 
 {% endif -%}


### PR DESCRIPTION
This adds an instance of Cloudflare's Turnstile widget to list submission forms. The widget is intentionally configured in non-interactive mode so as to never require interaction from users.

This is to be paired with server-side validation within the submission function, to ensure the function is only accessed for intentional form submissions.

Note that this currently uses the actual Turnstile site key for purposes of verifying the PR; I intend to remove that before merging so that it is only used for the actual site, and netlify previews will subsequently use the test key. (I would have liked to keep it active for previews, but unfortunately the domain configuration for the widget does not support wildcards, and netlify does not use a common higher-level subdomain for the app, so the common denominator is only `netlify.app`, which is excessively wide.)

I have already tested this via a branch deploy (see https://github.com/w3c/wai-evaluation-tools-list/pull/1193 and https://github.com/w3c/wai-evaluation-tools-list/pull/1197) but you are welcome to test it further.

## TODO before merging

* [x] - Remove `or site.env.NETLIFY` (and possibly collapse the two if/elses that will have the same condition)