### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/compress-images.yml
+++ b/.github/workflows/compress-images.yml
@@ -2,11 +2,14 @@ name: Compress images
 on: pull_request
 jobs:
   build:
+    # Only run on pull requests within the same repository, and not from forks.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     name: calibreapp/image-actions
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v6
-      - name: calibreapp/image-actions
-        uses: docker://calibreapp/github-image-actions
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+      - name: Compress PR images
+        uses: calibreapp/image-actions@9d037c06280028c110ff61c433ad4dc7d33c3c43 #v1.5.0


### PR DESCRIPTION
This PR:
- pins actions to a full-length commit SHA, following GitHub's recommendations
- bumps `checkout` from v6 to v7.0.1
- uses the `calibreapp/image-actions` GitHub repo instead of the docker image that was [last updated 5 years ago](https://hub.docker.com/layers/calibreapp/github-image-actions/latest/).
- sets more specific permissions

The workflow was tested successfully in a fork.